### PR TITLE
Fix module namespace for User

### DIFF
--- a/app/models/f1/admin.rb
+++ b/app/models/f1/admin.rb
@@ -1,4 +1,4 @@
 module F1
-  class Admin < User
+  class Admin < F1::User
   end
 end

--- a/lib/f1/version.rb
+++ b/lib/f1/version.rb
@@ -1,3 +1,3 @@
 module F1
-  VERSION = "0.0.9"
+  VERSION = "0.0.10"
 end


### PR DESCRIPTION
We have now a class called `User` on highlands_auth and this is having a conflict with the inheritance from F1::Admin.

This should fix it.